### PR TITLE
Avoid repetetive attempts to verify and confirm tx

### DIFF
--- a/controller/main.js
+++ b/controller/main.js
@@ -91,9 +91,9 @@ class MainController {
 
                     await U.wasteTime(delay);
                     await rskCtrl.confirmWithdrawRequest(txID);
-                    console.log(isConfirmed + "\n 'from' is now " + txID)
-                    from = txID
                 }
+                from = txID
+                console.log("'from' is now " + txID)
             }
             await U.wasteTime(5);
         }


### PR DESCRIPTION
Closes #22 

Better like this. Doesn't make any sense to iterate over a transaction if it was already confirmed.

The catch here: we always update the "from" variable