### PR TITLE
better retry logic for transaction scanning

### DIFF
--- a/controller/main.js
+++ b/controller/main.js
@@ -237,10 +237,10 @@ class MainController {
 
     async checkIfProcessed(txId, confirmations=3) {
         let cnt = 0;
-        let block = 'latest';
+        let block = 'pending';
 
         if (confirmations > 0) {
-            block = await this.cachedBlockNumber() - confirmations;
+            block = await this.cachedBlockNumber() - confirmations + 1;
         }
 
         while (true) {
@@ -301,8 +301,11 @@ class MainController {
      * 1. the provided btc address was derived from the same public keys and the same derivation scheme or not
      * btcAdr and txHash can't be null!
      * 2. the tx hash is valid
-     * 3. timestamp < 1h (work in progress)
-     * 4. todo: btc deposit address match
+     * 3. btc deposit address is duly signed by current signatories
+     * 4. the payment has not been marked consumed
+     * 5. the payment is entered into the table
+     *
+     * TODO: check that timestamp is recent
      */
     async verifyPaymentInfo({btcAdr, txHash, vout, web3Adr, signatures, txID}) {
         if (generatedBtcAddresses.indexOf(btcAdr) === -1) {


### PR DESCRIPTION
This now does the following logic:

Always scan starting from 1000 transactions *behind* from the last transaction we've ever reached. Then for any transaction in the range
1. check that we've not marked the transaction id as definitely processed in an in-memory Set.
2. check the processed status with *3 confirmations* from RSK. If it was processed 3 confirmations ago then mark it as definitely processed and skip to next transaction
3. if the transaction had not been processed with *3 confirmations* then check that the transaction is not processed in *pending*
4. if 2 and 3 both pass then and only then initiate confirmation and such.